### PR TITLE
Remove unused import

### DIFF
--- a/custom_components/smhialert/sensor.py
+++ b/custom_components/smhialert/sensor.py
@@ -29,9 +29,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME)
 from homeassistant.util import Throttle
-from homeassistant.components.rest.sensor import RestData
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
This import has changed in Home Assistant, and with block the integration from starting on > 2021.3.0.
Since it was not used, it's removed in this PR.