### PR TITLE
Localisation of 'Alert' state and ability to name sensors

### DIFF
--- a/custom_components/smhialert/sensor.py
+++ b/custom_components/smhialert/sensor.py
@@ -44,7 +44,7 @@ SCAN_INTERVAL = timedelta(minutes=5)
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_NAME, default=NAME): cv.string,
     vol.Optional(CONF_DISTRICT, default='all'): cv.string,
     vol.Optional(CONF_LANGUAGE, default='en'): cv.string
 })
@@ -53,9 +53,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     district = config.get(CONF_DISTRICT)
     language = config.get(CONF_LANGUAGE)
+    name = config.get(CONF_NAME)
     api = SMHIAlert(district, language)
 
-    add_entities([SMHIAlertSensor(api, NAME)], True)
+    add_entities([SMHIAlertSensor(api, name)], True)
 
 
 class SMHIAlertSensor(Entity):
@@ -196,7 +197,10 @@ Beskrivning:
 
             self.available = True
             if notice != "":
-                self.data['state'] = 'Alert'
+                if self.language == 'en':
+                  self.data['state'] = "Alert"
+                else:
+                  self.data['state'] = "Varning"
                 self.attributes['messages'] = msgs
                 self.attributes['notice'] = notice
         except Exception as e:


### PR DESCRIPTION
This PR proposes to add Swedish localisation of the 'Alert' state in the same way as 'No Alerts' (no other locales supported currently). It also suggests to add ability to name the sensor, in case you want several. For example, living near the coast, you may want both alerts for sea as well as land. And you want naming to be deterministic.

As as side note, we should really split out the lovelace card and try to get this into HACS, for maintainability. And maybe to get support into the Meteoalarm Card as well.